### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 jar {
-	baseName='scm-example'
+	archivesBaseName='scm-example'
 	version='1.0.0-SNAPSHOT'
 }
 


### PR DESCRIPTION
`baseName` has been [depreciated in the latest versions of Gradle](https://docs.gradle.org/5.2.1/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:archiveName:~:text=String%20baseName-,Note%3A%20This%20property%20is%20deprecated%20and%20will%20be%20removed%20in%20the%20next%20major%20version%20of%20Gradle.,-The%20base%20name). It's now just `archiveBaseName` if my understanding is correct